### PR TITLE
fix: record skipped and error test results

### DIFF
--- a/neotest.py
+++ b/neotest.py
@@ -12,6 +12,7 @@ def add_to_path():
     finally:
         sys.path = old_path
 
+
 with add_to_path():
     from neotest_python import main
 


### PR DESCRIPTION
## Summary
The unittest adapter was reporting skipped and errored tests as succeeded

Not reporting errors was a matter of simply not catching the `addError` as a distinct state from `addFailure`

Not reporting skipped tests was because the previous logic set all test results to `PASSED` and then afterwards merged them with the reported results. The merge logic only updates the status if the new value is "greater than" the old value, but `SKIPPED` has a lower value than `PASSED`, so it can never be set.

Given that all tests are going to be run, it doesn't seem necessary to set all the results to `PASSED` in the beginning, so I've removed that plus the merge logic. If there's a good reason for it to remain, I can rework the PR to fix the merge instead of removing it.

## Test Plan

- git clone https://github.com/stevearc/overseer-test-frameworks
- cd overseer-test-frameworks/python/unittest
- nvim tests/test_file.py
- `:lua require('neotest').run.run(vim.api.nvim_buf_get_name(0))`

Observe that the skipped test and the error test are properly reported

before:
![neotest before](https://user-images.githubusercontent.com/506791/172513771-96bf419b-ba10-4457-8fe1-91df6a2d5f2f.png)

after:
![neotest after](https://user-images.githubusercontent.com/506791/172513663-4209ac9a-91c1-419d-8c07-d676dd0e40e7.png)

