### PR TITLE
fix: unittest adapter can run specific tests/groups/files

### DIFF
--- a/neotest_python/unittest.py
+++ b/neotest_python/unittest.py
@@ -36,17 +36,24 @@ class UnittestNeotestAdapter(NeotestAdapter):
     def case_id(self, case: "TestCase | TestSuite") -> str:
         return "::".join(self.case_id_elems(case))
 
-    def id_to_test_specifier(self, case_id: str) -> str:
+    def id_to_unittest_args(self, case_id: str) -> List[str]:
         """Converts a neotest ID into test specifier for unittest"""
         pieces = case_id.split("::")
-        # If the ID is just a filename, return that
+        # If no ::, then the argument is a filepath
         if len(pieces) == 1:
-            return pieces[0]
-        # Otherwise, convert the ID into a dotted path, relative to current dir
-        relative_file = os.path.relpath(pieces[0], os.getcwd())
-        relative_stem = os.path.splitext(relative_file)[0]
-        relative_dotted = relative_stem.replace(os.sep, ".")
-        return f"{relative_dotted}.{'.'.join(pieces[1:])}"
+            test_path = pieces[0]
+            if os.path.isfile(test_path):
+                # Test files can be passed directly to unittest
+                return [test_path]
+            else:
+                # Directories need to be run via the 'discover' argument
+                return ["discover", "-s", test_path]
+        else:
+            # Otherwise, convert the ID into a dotted path, relative to current dir
+            relative_file = os.path.relpath(pieces[0], os.getcwd())
+            relative_stem = os.path.splitext(relative_file)[0]
+            relative_dotted = relative_stem.replace(os.sep, ".")
+            return [f"{relative_dotted}.{'.'.join(pieces[1:])}"]
 
     def run(self, args: List[str]) -> Dict:
         results = {}
@@ -103,8 +110,9 @@ class UnittestNeotestAdapter(NeotestAdapter):
 
         # Make sure we can import relative to current path
         sys.path.insert(0, os.getcwd())
-        specs = [self.id_to_test_specifier(case_id) for case_id in args]
-        argv = sys.argv[0:1] + specs
+        # We only get a single case ID as the argument
+        argv = sys.argv[0:1] + self.id_to_unittest_args(args[0])
+        print(argv)
         unittest.main(
             module=None,
             argv=argv,


### PR DESCRIPTION
## Summary

Neotest was unable to run a *single* test in a file. Actually, was always running *all* files discoverable by the default test runner.

This is due to how the args were getting passed in. The `argv` argument for `unittest.main()` expects a format [that is identical to sys.argv](https://github.com/python/cpython/blob/5849af7a80166e9e82040e082f22772bd7cf3061/Lib/unittest/main.py#L76-L77), i.e. the first element is the program name and the remainder are the program args. We were passing the test ID `<testfile>.py::TestClass::test_fn` as the only argument, so it was being used as the program name and unittest was running the default behavior, which is to discover and run all tests relative to the current directory.

The fix is to pass in the actual program name as the first arg, and to convert the test IDs to be the format expected by unittest. From `python -m unittest -h`
```
Examples:
  python -m unittest test_module               - run tests from test_module
  python -m unittest module.TestClass          - run tests from module.TestClass
  python -m unittest module.Class.test_method  - run specified test method
  python -m unittest path/to/test_file.py      - run tests from test_file.py
```

## Test Plan
* git clone https://github.com/stevearc/overseer-test-frameworks
* cd overseer-test-frameworks/python/unittest
* nvim tests/test_file.py
* Navigate to a test function
* `:lua require('neotest').run.run()`

before:
![neotest before](https://user-images.githubusercontent.com/506791/172522757-b9032ae8-b608-4083-9f8e-b98ffcd06436.png)


after:

![neotest after](https://user-images.githubusercontent.com/506791/172522778-03b9b19b-6638-41ea-900d-1426a064efdc.png)

I also confirmed that testing the entire file works as before
`:lua require('neotest').run.run(vim.api.nvim_buf_get_name(0))`
![neotest file](https://user-images.githubusercontent.com/506791/172523021-6ea77bfb-ab27-48a9-aba9-dc4666134354.png)

